### PR TITLE
Make Optional implement Iterable

### DIFF
--- a/lib/optional.dart
+++ b/lib/optional.dart
@@ -14,12 +14,14 @@
 
 library quiver.optional;
 
+import 'dart:collection';
+
 /// A value that might be absent.
 ///
 /// Use Optional as an alternative to allowing fields, parameters or return
 /// values to be null. It signals that a value is not required and provides
 /// convenience methods for dealing with the absent case.
-class Optional<T> {
+class Optional<T> extends IterableBase<T> {
   final T _value;
 
   /// Constructs an empty Optional.
@@ -89,6 +91,10 @@ class Optional<T> {
         ? new Optional.absent()
         : new Optional.of(transformer(_value));
   }
+
+  @override
+  Iterator<T> get iterator =>
+      isPresent ? <T>[_value].iterator : new Iterable<T>.empty().iterator;
 
   /// Delegates to the underlying [value] hashCode.
   int get hashCode => _value.hashCode;

--- a/test/optional_test.dart
+++ b/test/optional_test.dart
@@ -110,5 +110,22 @@ main() {
       expect(new Optional<int>.fromNullable(null).toString(),
           equals('Optional { absent }'));
     });
+
+    test('length when absent should return 0', () {
+      expect(const Optional.absent().length, equals(0));
+    });
+
+    test('length when present should return 1', () {
+      expect(new Optional<int>.of(1).length, equals(1));
+    });
+
+    test('expand should behave as equivalent iterable', () {
+      final optionals = <Optional<int>>[
+        new Optional<int>.of(1),
+        const Optional.absent(),
+        new Optional<int>.of(2)
+      ].expand((i) => i);
+      expect(optionals, orderedEquals([1, 2]));
+    });
   });
 }


### PR DESCRIPTION
Implementing `Iterable` allows an `Optional`s to be passed into anything expecting an `Iterable` and facilitates common cases like

```
final optionals = <Optional<int>>[
        new Optional<int>.of(1),
        const Optional.absent(),
        new Optional<int>.of(2)
      ];
final ints = optionals.expand((i) => i); // (1, 2)
```

Note: this PR is a dupe of https://github.com/google/quiver-dart/pull/289. No idea where PRs should be filed now. Confusing
